### PR TITLE
Visualize markers overlaid on signals

### DIFF
--- a/paintwidget.py
+++ b/paintwidget.py
@@ -1,13 +1,16 @@
 from PyQt5.QtCore import QThread, Qt, pyqtSignal
 from PyQt5.QtGui import QPalette, QPainter, QPen
 from PyQt5.QtWidgets import QWidget
-from pylsl import StreamInlet, resolve_streams, cf_string
+import pylsl
 import math
+
+
+CHANNEL_Y_FILL = 0.7  # How much of the per-channel vertical space is filled.  > 1 will overlap the lines.
 
 
 class DataThread(QThread):
     updateStreamNames = pyqtSignal(list, int)
-    sendSignalChunk = pyqtSignal(int, list)
+    sendData = pyqtSignal(list, list, list, list)
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -22,12 +25,15 @@ class DataThread(QThread):
         self.downSamplingFactor = None
         self.downSamplingBuffer = None
         self.inlet = None
+        self.mrk_inlet = None
         self.sig_strm_idx = None
+        self.mrk_strm_idx = None
 
     def update_streams(self):
         if not self.streams:
-            self.streams = resolve_streams(wait_time=1.0)
+            self.streams = pylsl.resolve_streams(wait_time=1.0)
             self.sig_strm_idx = -1
+            self.mrk_strm_idx = -1
             for k, stream in enumerate(self.streams):
                 self.metadata.append({
                     "name": stream.name(),
@@ -35,123 +41,178 @@ class DataThread(QThread):
                     "ch_format": stream.channel_format(),
                     "srate": stream.nominal_srate()
                 })
-                if self.sig_strm_idx == -1 and stream.channel_format() not in ["String", cf_string]:
+                if self.sig_strm_idx == -1 and stream.channel_format() not in ["String", pylsl.cf_string]:
                     self.sig_strm_idx = k
+                if self.mrk_strm_idx == -1 and\
+                    stream.channel_format() in ["String", pylsl.cf_string] and\
+                        stream.nominal_srate() == pylsl.IRREGULAR_RATE:
+                    self.mrk_strm_idx = k
 
-            if self.sig_strm_idx != -1:
+            if self.mrk_strm_idx >= 0:
+                mrk_stream = self.streams[self.mrk_strm_idx]
+                self.mrk_inlet = pylsl.StreamInlet(mrk_stream)
+
+            if self.sig_strm_idx >= 0:
                 sig_stream = self.streams[self.sig_strm_idx]
                 self.srate = int(sig_stream.nominal_srate())
                 self.downSampling = False if self.srate <= 1000 else True
                 self.chunkSize = round(self.srate / self.chunksPerScreen * self.seconds_per_screen)
+                self.seconds_per_screen = self.chunksPerScreen * self.chunkSize / self.srate
 
                 if self.downSampling:
                     self.downSamplingFactor = round(self.srate / 1000)
                     self.downSamplingBuffer = [[0 for m in range(int(sig_stream.channel_count()))]
                                                for n in range(round(self.chunkSize/self.downSamplingFactor))]
 
-                self.inlet = StreamInlet(sig_stream)
+                self.inlet = pylsl.StreamInlet(sig_stream)
                 self.updateStreamNames.emit(self.metadata, self.sig_strm_idx)
                 self.start()
 
     def run(self):
         if self.streams:
             while True:
-                chunk, timestamps = self.inlet.pull_chunk(max_samples=self.chunkSize, timeout=1)
-                if timestamps:
+                send_data, send_ts = self.inlet.pull_chunk(max_samples=self.chunkSize, timeout=1)
+                if send_ts and self.downSampling:
+                    for m in range(round(self.chunkSize / self.downSamplingFactor)):
+                        end_idx = min((m + 1) * self.downSamplingFactor, len(send_data))
+                        for ch_idx in range(int(self.streams[self.sig_strm_idx].channel_count())):
+                            buf = [send_data[n][ch_idx] for n in range(m * self.downSamplingFactor, end_idx)]
+                            self.downSamplingBuffer[m][ch_idx] = sum(buf) / len(buf)
+                    send_data = self.downSamplingBuffer
 
-                    if self.downSampling:
-                        for k in range(int(self.streams[self.sig_strm_idx].channel_count())):
-                            for m in range(round(self.chunkSize/self.downSamplingFactor)):
-                                end_idx = min((m+1) * self.downSamplingFactor, len(chunk))
-                                buf = [chunk[n][k] for n in range(m * self.downSamplingFactor, end_idx)]
-                                self.downSamplingBuffer[m][k] = sum(buf) / len(buf)
-                        self.sendSignalChunk.emit(self.chunk_idx, self.downSamplingBuffer)
-                    else:
-                        self.sendSignalChunk.emit(self.chunk_idx, chunk)
+                send_mrk_data, send_mrk_ts = self.mrk_inlet.pull_chunk()
 
-                    if self.chunk_idx < self.chunksPerScreen:
-                        self.chunk_idx += 1
-                    else:
-                        self.chunk_idx = 0
+                if any([send_ts, send_mrk_ts]):
+                    self.sendData.emit(send_ts, send_data, send_mrk_ts, send_mrk_data)
 
 
 class PaintWidget(QWidget):
 
     def __init__(self, widget):
         super().__init__()
-        self.idx = 0
+        self.chunk_idx = 0
         self.channelHeight = 0
-        self.interval = 0
-        self.dataBuffer = []
+        self.px_per_samp = 0
+        self.dataBuffer = None
+        self.markerBuffer = None
         self.lastY = []
         self.scaling = []
         self.mean = []
-
+        self.t0 = 0
         pal = QPalette()
         pal.setColor(QPalette.Background, Qt.white)
         self.setAutoFillBackground(True)
         self.setPalette(pal)
 
         self.dataTr = DataThread(self)
-        self.dataTr.sendSignalChunk.connect(self.get_data_chunk)
+        self.dataTr.sendData.connect(self.get_data)
 
-    def get_data_chunk(self, chunk_idx, buffer):
-        if not self.mean:
-            self.mean = [0 for k in range(len(buffer[0]))]
-            self.scaling = [0 for k in range(len(buffer[0]))]
-        self.dataBuffer = buffer
+    def get_data(self, sig_ts, sig_buffer, marker_ts, marker_buffer):
+        update_x0 = float(self.width())
+        update_width = 0.
 
-        self.idx = chunk_idx
-        self.update(self.idx * (self.width() / self.dataTr.chunksPerScreen) - self.interval,
-                    0,
-                    self.width() / self.dataTr.chunksPerScreen,
-                    self.height())
+        # buffer should have exactly self.dataTr.chunkSize samples or be empty
+        if any(sig_ts):
+            if not self.mean:
+                self.mean = [0 for _ in range(len(sig_buffer[0]))]
+                self.scaling = [0 for _ in range(len(sig_buffer[0]))]
+            if self.chunk_idx == 0:
+                self.t0 = sig_ts[0]
+            self.dataBuffer = sig_buffer
+            px_per_chunk = self.width() / self.dataTr.chunksPerScreen
+            update_x0 = self.chunk_idx * px_per_chunk
+            update_width = px_per_chunk
+
+        if any(marker_ts):
+            px_out = []
+            ms_out = []
+            px_per_sec = self.width() / self.dataTr.seconds_per_screen
+            for ts, ms in zip(marker_ts, marker_buffer):
+                if any(sig_ts):  # Relative to signal timestamps
+                    this_px = update_x0 + (ts - sig_ts[0]) * px_per_sec
+                    if 0 <= this_px <= self.width():
+                        px_out.append(this_px)
+                        ms_out.append(','.join(ms))
+                else:
+                    # TODO: Check samples vs pixels for both data stream and marker stream.
+                    # I think there is some rounding error.
+                    
+                    if self.t0 <= ts <= (self.t0 + self.dataTr.seconds_per_screen):
+                        px_out.append((ts - self.t0) * px_per_sec)
+                        ms_out.append(','.join(ms))
+            self.markerBuffer = zip(px_out, ms_out)
+
+            update_x0 = min(update_x0, min(px_out))
+            update_width = max(update_width, max([_ - update_x0 for _ in px_out]))
+
+        if any(sig_ts) and update_x0 == sig_ts[0]:
+            update_x0 -= self.px_per_samp  # Offset to connect with previous sample
+
+        # Repaint only the region of the screen containing this data chunk.
+        if update_width > 0:
+            self.update(int(update_x0), 0, int(update_width + 1), self.height())
 
     def paintEvent(self, event):
-        if self.dataBuffer:
-            painter = QPainter(self)
+        painter = QPainter(self)
+        if self.dataBuffer is not None:
             painter.setPen(QPen(Qt.blue))
 
-            self.channelHeight = self.height() / len(self.dataBuffer[0])
-            self.interval = self.width() / self.dataTr.chunksPerScreen / len(self.dataBuffer)
+            n_samps = len(self.dataBuffer)
+            n_chans = len(self.dataBuffer[0])
+
+            self.channelHeight = self.height() / n_chans
+            self.px_per_samp = self.width() / self.dataTr.chunksPerScreen / n_samps
 
             # ======================================================================================================
             # Calculate Trend and Scaling
             # ======================================================================================================
-            if self.idx == 0 or not self.mean:
-                for k in range(len(self.dataBuffer[0])):
-                    column = [row[k] for row in self.dataBuffer]
-                    self.mean[k] = sum(column) / len(column)
+            if self.chunk_idx == 0 or not self.mean:
+                for chan_idx in range(n_chans):
+                    samps_for_chan = [frame[chan_idx] for frame in self.dataBuffer]
+                    self.mean[chan_idx] = sum(samps_for_chan) / len(samps_for_chan)
 
-                    for m in range(len(column)):
-                        column[m] -= self.mean[k]
+                    for m in range(len(samps_for_chan)):
+                        samps_for_chan[m] -= self.mean[chan_idx]
 
-                    self.scaling[k] = self.channelHeight * 0.7 / (max(column) - min(column) + 0.0000000000001)
+                    data_range = (max(samps_for_chan) - min(samps_for_chan) + 0.0000000000001)
+                    self.scaling[chan_idx] = self.channelHeight * CHANNEL_Y_FILL / data_range
 
             # ======================================================================================================
             # Trend Removal and Scaling
             # ======================================================================================================
-            for k in range(len(self.dataBuffer[0])):
-                for m in range(len(self.dataBuffer)):
-                    self.dataBuffer[m][k] -= self.mean[k]
-                    self.dataBuffer[m][k] *= self.scaling[k]
+            for samp_idx in range(n_samps):
+                for chan_idx in range(n_chans):
+                    self.dataBuffer[samp_idx][chan_idx] -= self.mean[chan_idx]
+                    self.dataBuffer[samp_idx][chan_idx] *= self.scaling[chan_idx]
 
             # ======================================================================================================
             # Plot
             # ======================================================================================================
-            for k in range(len(self.dataBuffer[0])):
+            px_per_chunk = self.width() / self.dataTr.chunksPerScreen
+            x0 = self.chunk_idx * px_per_chunk
+            for ch_idx in range(n_chans):
+                chan_offset = (ch_idx + 0.5) * self.channelHeight
                 if self.lastY:
-                    if not math.isnan(self.lastY[k]) and not math.isnan(self.dataBuffer[0][k]):
-                        painter.drawLine(self.idx * (self.width() / self.dataTr.chunksPerScreen) - self.interval,
-                                         -self.lastY[k] + (k + 0.5) * self.channelHeight,
-                                         self.idx * (self.width() / self.dataTr.chunksPerScreen),
-                                         -self.dataBuffer[0][k] + (k + 0.5) * self.channelHeight)
+                    if not math.isnan(self.lastY[ch_idx]) and not math.isnan(self.dataBuffer[0][ch_idx]):
+                        painter.drawLine(x0 - self.px_per_samp,
+                                         -self.lastY[ch_idx] + chan_offset,
+                                         x0,
+                                         -self.dataBuffer[0][ch_idx] + chan_offset)
 
-                for m in range(len(self.dataBuffer) - 1):
-                    if not math.isnan(self.dataBuffer[m][k]) and not math.isnan(self.dataBuffer[m+1][k]):
-                        painter.drawLine(m * self.interval + self.idx * (self.width() / self.dataTr.chunksPerScreen),
-                                         -self.dataBuffer[m][k] + (k + 0.5) * self.channelHeight,
-                                         (m + 1)*self.interval + self.idx*(self.width() / self.dataTr.chunksPerScreen),
-                                         -self.dataBuffer[m+1][k] + (k + 0.5) * self.channelHeight)
+                for m in range(n_samps - 1):
+                    if not math.isnan(self.dataBuffer[m][ch_idx]) and not math.isnan(self.dataBuffer[m+1][ch_idx]):
+                        painter.drawLine(x0 + m * self.px_per_samp,
+                                         -self.dataBuffer[m][ch_idx] + chan_offset,
+                                         x0 + (m + 1) * self.px_per_samp,
+                                         -self.dataBuffer[m+1][ch_idx] + chan_offset)
 
+            # Reset for next iteration
+            self.chunk_idx = (self.chunk_idx + 1) % self.dataTr.chunksPerScreen  # For next iteration
             self.lastY = self.dataBuffer[-1]
+            self.dataBuffer = None
+
+        if self.markerBuffer is not None:
+            painter.setPen(QPen(Qt.red))
+            for px, mrk in self.markerBuffer:
+                painter.drawLine(px, 0, px, self.height())
+            self.markerBuffer = None

--- a/paintwidget.py
+++ b/paintwidget.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import QThread, Qt, pyqtSignal
 from PyQt5.QtGui import QPalette, QPainter, QPen
 from PyQt5.QtWidgets import QWidget
-from pylsl import StreamInlet, resolve_streams
+from pylsl import StreamInlet, resolve_streams, cf_string
 import math
 
 
@@ -35,7 +35,7 @@ class DataThread(QThread):
                     "ch_format": stream.channel_format(),
                     "srate": stream.nominal_srate()
                 })
-                if self.sig_strm_idx == -1 and stream.channel_format() not in ["String"]:
+                if self.sig_strm_idx == -1 and stream.channel_format() not in ["String", cf_string]:
                     self.sig_strm_idx = k
 
             if self.sig_strm_idx != -1:

--- a/paintwidget.py
+++ b/paintwidget.py
@@ -143,10 +143,11 @@ class PaintWidget(QWidget):
                     if self.t0 <= ts <= (self.t0 + self.dataTr.seconds_per_screen):
                         px_out.append((ts - self.t0) * px_per_sec)
                         ms_out.append(','.join(ms))
-            self.markerBuffer = zip(px_out, ms_out)
-
-            update_x0 = min(update_x0, min(px_out))
-            update_width = max(update_width, max([_ - update_x0 for _ in px_out]))
+            if any(px_out):
+                # Sometimes the marker might happen just off screen so we lose it.
+                self.markerBuffer = zip(px_out, ms_out)
+                update_x0 = min(update_x0, min(px_out))
+                update_width = max(update_width, max([_ - update_x0 for _ in px_out]))
 
         if any(sig_ts) and update_x0 == sig_ts[0]:
             update_x0 -= self.px_per_samp  # Offset to connect with previous sample

--- a/paintwidget.py
+++ b/paintwidget.py
@@ -218,4 +218,5 @@ class PaintWidget(QWidget):
             painter.setPen(QPen(Qt.red))
             for px, mrk in self.markerBuffer:
                 painter.drawLine(px, 0, px, self.height())
+                painter.drawText(px - 2 * self.px_per_samp, 0.95 * self.height(), mrk)
             self.markerBuffer = None

--- a/sigvisualizer.py
+++ b/sigvisualizer.py
@@ -24,31 +24,31 @@ class SigVisualizer(QMainWindow):
         self.ui.toggleButton.setIcon(QIcon("icons/chevron_left.svg"))
         self.ui.toggleButton.setIconSize(QSize(30, 30))
 
-        self.ui.toggleButton.clicked.connect(self.togglePanel)
+        self.ui.toggleButton.clicked.connect(self.toggle_panel)
         self.ui.updateButton.clicked.connect(
-            self.ui.widget.dataTr.updateStreams)
+            self.ui.widget.dataTr.update_streams)
         self.ui.widget.dataTr.updateStreamNames.connect(
-            self.updateMetadataWidget)
+            self.update_metadata_widget)
         self.panelHidden = False
 
-    def updateMetadataWidget(self, metadata, defaultIdx):
+    def update_metadata_widget(self, metadata, default_idx):
         for k in range(len(metadata)):
             item = QTreeWidgetItem(self.ui.treeWidget)
             item.setText(0, metadata[k]["name"])
 
             for m in range(metadata[k]["ch_count"]):
-                channelItem = QTreeWidgetItem(item)
-                channelItem.setText(0, 'Channel {}'.format(m+1))
-                channelItem.setCheckState(0, Qt.Checked)
+                channel_item = QTreeWidgetItem(item)
+                channel_item.setText(0, 'Channel {}'.format(m+1))
+                channel_item.setCheckState(0, Qt.Checked)
 
-            item.setExpanded(True if k == defaultIdx else False)
+            item.setExpanded(True if k == default_idx else False)
             self.ui.treeWidget.addTopLevelItem(item)
 
         self.ui.treeWidget.setAnimated(True)
         self.statusBar.showMessage(
-            "Sampling rate: {}Hz".format(metadata[defaultIdx]["srate"]))
+            "Sampling rate: {}Hz".format(metadata[default_idx]["srate"]))
 
-    def togglePanel(self):
+    def toggle_panel(self):
         if self.panelHidden:
             self.panelHidden = False
             self.ui.treeWidget.show()


### PR DESCRIPTION
The first 3 commits are part of #12 

The last commit changes quite a bit of code, but it enables visualizing markers overlaid on top of signals. The only way to do this without blanking out the entire region under the marker is to update both signals and markers in the same painter update. This required a bit of restructuring.